### PR TITLE
Add multi-source features

### DIFF
--- a/config-enterprise.ini.sample
+++ b/config-enterprise.ini.sample
@@ -18,3 +18,7 @@ password = plaintext_pass\/\/ord
 # If unsure, just using '%c' will default to the locale’s appropriate date and time representation.
 #date = %A %b %d, %Y at %H:%M GMT # Sample: Friday Sep 13, 2013 at 22:58 GMT
 
+# If importing issues from multiple sources you can specify a title prefix and label to apply to all issues
+#issue_title_prefix = [old-repo-name]
+#issue_label = old-repo-name
+

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -16,3 +16,6 @@ repository = OctoDog/Hello-World
 # If unsure, just using '%c' will default to the locale’s appropriate date and time representation.
 #date = %A %b %d, %Y at %H:%M GMT # Sample: Friday Sep 13, 2013 at 22:58 GMT
 
+# If importing issues from multiple sources you can specify a title prefix and label to apply to all issues
+#issue_title_prefix = [old-repo-name]
+#issue_label = old-repo-name

--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -351,6 +351,22 @@ def import_issues_golden_comet(issues):
 		issue_migration = {}
 		new_issue = {}
 		new_issue['title'] = issue['title']
+
+		#Add custom title prefix?
+		if config.has_option('format', 'issue_title_prefix'):
+			new_issue['title'] = config.get('format', 'issue_title_prefix') + " " + issue['title']
+
+		#Add new label
+		if config.has_option('format', 'issue_label'):
+			new_lable = {
+				"name": config.get('format', 'issue_label'),
+				"color": '000000' #Default to black, easy to find and can be changed globally later
+			}	
+			if 'labels' in issue:
+				issue['labels'].append(new_lable)
+			else:
+				issue['labels'] = [new_lable]
+
 		if issue['closed_at'] is not None:
 			new_issue['closed_at'] = issue['closed_at']
 			new_issue['closed'] = True

--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -58,6 +58,8 @@ def init_config():
 	arg_parser.add_argument('--use-github-import-api', dest='use_github_import_api', action='store_true', help="Use the new github import api")
 	
 	arg_parser.add_argument('--issue-template', help="Specify a template file for use with issues.")
+	arg_parser.add_argument('--issue-title-prefix', help="Specify a prefix for issue titles.")
+	arg_parser.add_argument('--issue-label', help="Specify a label to add to all new issues.")
 	arg_parser.add_argument('--comment-template', help="Specify a template file for use with comments.")
 	arg_parser.add_argument('--pull-request-template', help="Specify a template file for use with pull requests.")
 		
@@ -101,6 +103,8 @@ def init_config():
 	if args.target: config.set('target', 'repository', args.target)
 	
 	if args.issue_template: config.set('format', 'issue_template', args.issue_template)
+	if args.issue_title_prefix: config.set('format', 'issue_title_prefix', args.issue_title_prefix)
+	if args.issue_label: config.set('format', 'issue_label', args.issue_label)
 	if args.comment_template: config.set('format', 'comment_template', args.comment_template)
 	if args.pull_request_template: config.set('format', 'pull_request_template', args.pull_request_template)
 	
@@ -485,6 +489,21 @@ def import_issues(issues):
 		new_issue = {}
 		new_issue['title'] = issue['title']
 		
+		#Add custom title prefix?
+		if config.has_option('format', 'issue_title_prefix'):
+			new_issue['title'] = config.get('format', 'issue_title_prefix') + " " + issue['title']
+
+		#Add new label
+		if config.has_option('format', 'issue_label'):
+			new_lable = {
+				"name": config.get('format', 'issue_label'),
+				"color": '000000' #Default to black, easy to find and can be changed globally later
+			}	
+			if 'labels' in issue:
+				issue['labels'].append(new_lable)
+			else:
+				issue['labels'] = [new_lable]
+
 		# Temporary fix for marking closed issues
 		if issue['closed_at']:
 			new_issue['state'] = "closed"


### PR DESCRIPTION
I used this modified script to successfully migrate issues from two repos ([interledger/java-ilp-core](https://github.com/interledger/java-ilp-core) and [interledger/java-crypto-conditions](https://github.com/interledger/java-crypto-conditions)) into one target ([hyperledger/quilt](https://github.com/hyperledger/quilt))

The changes add two new config parameters that allow you to specify a title prefix and/or a new label for all issues.

If these are provided all migrated issues will have the prefix appended to their title and will be given the new label.

DISCLAIMER: This was tested on the original script at IQAndreas/github-issues-importer but that seems to be dead so have rebased on this updated script.